### PR TITLE
Fixes setup:di:compile issues

### DIFF
--- a/Controller/GetCart/Index.php
+++ b/Controller/GetCart/Index.php
@@ -37,7 +37,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->_customerSession = $customerSession;
         $this->_orderCollectionFactory = $orderCollectionFactory;
         $this->_scopeConfig = $scopeConfig;
-        $this->_urlinterface = $context->getUrlBuilder();
+        $this->_urlinterface = $context->getUrl();
         return parent::__construct($context);
     }
 

--- a/Controller/GetCart/Index.php
+++ b/Controller/GetCart/Index.php
@@ -20,17 +20,17 @@ class Index extends \Magento\Framework\App\Action\Action
 	 * @var ScopeConfigInterface
 	 */
     protected $_scopeConfig;
-    
+
 	/**
 	 * @var UrlInterface
 	 */
     protected $_urlinterface;
-    
+
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \Magento\Framework\View\Element\Template\Context $templateContext,
-        \Magento\Checkout\Model\Cart $cart, 
-        \Magento\Customer\Model\Session $customerSession, 
+        \Magento\Checkout\Model\Cart $cart,
+        \Magento\Customer\Model\Session $customerSession,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
     ){
@@ -40,7 +40,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->_scopeConfig = $scopeConfig;
         $this->_urlinterface = $templateContext->getUrlBuilder();
         return parent::__construct($context);
-    } 
+    }
 
     public function execute()
     {
@@ -51,10 +51,10 @@ class Index extends \Magento\Framework\App\Action\Action
         /** @var     \Magento\Framework\App\ResponseInterface|\Magento\Framework\App\Response\Http $response */
         $response = $om->get('Magento\Framework\App\ResponseInterface');
         $response->setHeader('Content-type', 'application/json', $overwriteExisting = true);
-        $response->setBody($custom_variables); 
+        $response->setBody($custom_variables);
         return $response;
     }
-    
+
     /**
      * Returns last order details.
      * @return string

--- a/Controller/GetCart/Index.php
+++ b/Controller/GetCart/Index.php
@@ -28,7 +28,6 @@ class Index extends \Magento\Framework\App\Action\Action
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
-        \Magento\Framework\View\Element\Template\Context $templateContext,
         \Magento\Checkout\Model\Cart $cart,
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
@@ -38,7 +37,7 @@ class Index extends \Magento\Framework\App\Action\Action
         $this->_customerSession = $customerSession;
         $this->_orderCollectionFactory = $orderCollectionFactory;
         $this->_scopeConfig = $scopeConfig;
-        $this->_urlinterface = $templateContext->getUrlBuilder();
+        $this->_urlinterface = $context->getUrlBuilder();
         return parent::__construct($context);
     }
 


### PR DESCRIPTION
Came across this error during a code deployment as part of the `php bin/magento setup:di:compile` step:

```bash
Errors during compilation: LiveChat\LiveChat\Controller\GetCart\Index Incorrect dependency in class LiveChat\LiveChat\Controller\GetCart\Index.php \Magento\Framework\App\Config\ScopeConfigInterface already exists in context object.
```

Using Magento 2.1.x in production mode, the injection of `\Magento\Framework\App\Config\ScopeConfigInterface` conflicts with the use of `\Magento\Framework\View\Element\Template\Context` as that `ScopeConfigInterface` is already injected in the Context class. The `$templateContext` object is only being used to get the `\Magento\Framework\UrlInterface` so it can be refactored out to use `$context->getUrl()` (from `\Magento\Framework\App\Action\Context::getUrl()`) or simply use the protected `$_url` from the parent `\Magento\Framework\App\Action\Action::__construct()` so the `\Magento\Framework\View\Element\Template\Context` injection can be completely removed and thus fixing the `\Magento\Framework\App\Config\ScopeConfigInterface` compilation error.